### PR TITLE
feat: notify users on event date or venue change

### DIFF
--- a/app/apps.py
+++ b/app/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig # type: ignore
 class AppConfig(AppConfig):   # type: ignore
     default_auto_field = "django.db.models.BigAutoField"
     name = "app"
+
+    def ready(self):
+        import app.signals 

--- a/app/signals.py
+++ b/app/signals.py
@@ -1,6 +1,7 @@
-from django.db.models.signals import pre_save
+from django.db.models.signals import pre_save, post_save
 from django.dispatch import receiver
-from .models import Event
+from django.utils.timezone import localtime
+from .models import Event, Notification, Ticket
 
 @receiver(pre_save, sender=Event)
 def detect_event_update(sender, instance, **kwargs):
@@ -13,6 +14,8 @@ def detect_event_update(sender, instance, **kwargs):
         return
 
     changes = []
+    instance._old_scheduled_at = previous.scheduled_at
+    instance._old_venue = previous.venue.name if previous.venue else "N/A"
 
     if instance.scheduled_at != previous.scheduled_at:
         changes.append(("scheduled_at", previous.scheduled_at, instance.scheduled_at))
@@ -21,3 +24,46 @@ def detect_event_update(sender, instance, **kwargs):
         changes.append(("venue", previous.venue.name if previous.venue else "N/A", instance.venue.name if instance.venue else "N/A"))
 
     instance._detected_changes = changes if changes else None
+
+@receiver(post_save, sender=Event)
+def create_notification_on_event_update(sender, instance, created, **kwargs):
+    if created:
+        return  
+
+    changes = getattr(instance, '_detected_changes', None)
+    if not changes:
+        return
+
+    change_descriptions = []
+
+    for field, old, new in changes:
+        if field == "scheduled_at":
+            field_label = "la fecha"
+            old = localtime(old).strftime("%d/%m/%Y a las %H:%M Hs.")
+            new = localtime(new).strftime("%d/%m/%Y a las %H:%M Hs.")
+
+        elif field == "venue":
+            field_label = "el lugar"
+
+        else:
+            field_label = field
+        change_descriptions.append(f"{field_label} de {old} al {new}")
+        
+    change_text = " y ".join(change_descriptions)
+
+    date_part = localtime(instance._old_scheduled_at).strftime("%d/%m/%Y")
+    venue_part = instance._old_venue
+    
+    title = f"Actualización del evento {instance.title} - {date_part} - {venue_part} "
+    message = f"El evento {instance.title} ha cambiado {change_text}."
+
+    notif = Notification.objects.create(
+        title=title,
+        message=message,
+        priority="High",
+        event=instance
+    )
+
+    user_ids = Ticket.objects.filter(event=instance).values_list("user_id", flat=True).distinct()
+    notif.users.set(user_ids)
+    notif.save()

--- a/app/signals.py
+++ b/app/signals.py
@@ -1,0 +1,23 @@
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+from .models import Event
+
+@receiver(pre_save, sender=Event)
+def detect_event_update(sender, instance, **kwargs):
+    if not instance.pk:
+        return  
+
+    try:
+        previous = Event.objects.get(pk=instance.pk)
+    except Event.DoesNotExist:
+        return
+
+    changes = []
+
+    if instance.scheduled_at != previous.scheduled_at:
+        changes.append(("scheduled_at", previous.scheduled_at, instance.scheduled_at))
+
+    if instance.venue != previous.venue:
+        changes.append(("venue", previous.venue.name if previous.venue else "N/A", instance.venue.name if instance.venue else "N/A"))
+
+    instance._detected_changes = changes if changes else None


### PR DESCRIPTION
This PR implements notifications for users holding tickets when an Event's scheduled date or venue changes.

- Implements a pre_save signal to detect changes in scheduled_at and venue.
- Implements a post_save signal to create Notification objects and associate them with affected users.
- Notification titles include the event name and previous date/venue for better clarity.
- Notification message details which fields were updated, showing old and new values.

Note: Tests will be added in a follow-up PR.

Related issue: #1