### PR TITLE
feat(tickets): Validate max 4 tickets per event purchase

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -148,6 +148,10 @@ class TicketForm(forms.ModelForm):
                 event=self.event
             ).aggregate(total=Sum('quantity'))['total'] or 0
 
+            # Restar el valor original si se está editando un ticket existente
+            if self.instance and self.instance.pk:
+                total_anteriores -= self.instance.quantity
+
             if total_anteriores + quantity > 4:
                 raise forms.ValidationError("No puede comprar más de 4 entradas para este evento.")
 

--- a/app/forms.py
+++ b/app/forms.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from django import forms
 from .models import Event, Notification, RefundRequest, Ticket, User, Venue,Rating,Comment, Category
 import re
+from django.db.models import Sum
+
 
 class NotificationForm(forms.ModelForm):
     event = forms.ModelChoiceField(
@@ -92,6 +94,14 @@ class NotificationForm(forms.ModelForm):
             
 
 class TicketForm(forms.ModelForm):
+
+    # Recibe como parametro el usuario y el evento (los cuales los utilizo en la feature del maximo de 4 entradas por evento)
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop('user', None)
+        self.event = kwargs.pop('event', None)
+        super().__init__(*args, **kwargs)
+    
+
     # Campos de la tarjeta, validaciones específicas en los métodos clean_* correspondientes
     card_name = forms.CharField(label="Nombre en la tarjeta", max_length=30, widget=forms.TextInput(attrs={'class': 'form-control','placeholder': 'Juan Peres'}))
     card_number = forms.CharField(label="Número de tarjeta", max_length=25, min_length=13, widget=forms.TextInput(attrs={'class': 'form-control','placeholder': '1234 5678 9012 3456'}))
@@ -122,18 +132,27 @@ class TicketForm(forms.ModelForm):
     widget=forms.TextInput(attrs={'class': 'form-control text-center', 'placeholder': '0'})
     )
 
+    # verifica que el usuario no exeda el maximo de 4 entradas en un mismo evento (ya sea en una sola compra o en varias)
     def clean_quantity(self):
         quantity = self.cleaned_data.get('quantity')
 
-        # Verificar si quantity es None o 0
         if quantity is None:
-            raise forms.ValidationError("No ha seleccionado la cantidad de tickets a comprar")
+            raise forms.ValidationError("No ha seleccionado la cantidad de tickets a comprar.")
 
-        # Validar que la cantidad no sea mayor a 120
         if quantity > 120:
             raise forms.ValidationError("La cantidad no puede ser mayor a 120.")
 
+        if self.user and self.event:
+            total_anteriores = Ticket.objects.filter(
+                user=self.user,
+                event=self.event
+            ).aggregate(total=Sum('quantity'))['total'] or 0
+
+            if total_anteriores + quantity > 4:
+                raise forms.ValidationError("No puede comprar más de 4 entradas para este evento.")
+
         return quantity
+
     
     def clean_card_name(self):
         name = self.cleaned_data.get('card_name')

--- a/app/views.py
+++ b/app/views.py
@@ -375,7 +375,7 @@ def ticket_create(request, event_id):
     event = get_object_or_404(Event, id=event_id)
 
     if request.method == "POST":
-        form = TicketForm(request.POST)
+        form = TicketForm(request.POST, user=request.user, event=event)
         if form.is_valid():
             ticket = form.save(commit=False)  
             ticket.user = request.user
@@ -384,7 +384,7 @@ def ticket_create(request, event_id):
             messages.success(request, "Ticket creado exitosamente.", extra_tags='ticket')
             return redirect("ticket_list")
     else:
-        form = TicketForm()
+        form = TicketForm(user=request.user, event=event)
 
     return render(request, "app/ticket_form.html", {"form": form, "event": event})
 
@@ -405,13 +405,13 @@ def ticket_update(request, ticket_id):
     event = ticket.event 
 
     if request.method == "POST":
-        form = TicketForm(request.POST, instance=ticket)
+        form = TicketForm(request.POST, instance=ticket, user=request.user, event=event)
         if form.is_valid():
             form.save()
             messages.success(request, "Ticket actualizado exitosamente.", extra_tags='ticket')
             return redirect("ticket_list")
     else:
-        form = TicketForm(instance=ticket)
+        form = TicketForm(instance=ticket, user=request.user, event=event)
 
     return render(request, "app/ticket_form.html", {"form": form,  'event': event})
 


### PR DESCRIPTION
## Description

Implements the feature that allows registered users to purchase up to 4 tickets per event. This validation applies to both new purchases and accumulated ones.

## Changes Made

- Added validation in the form (`TicketForm`) to prevent users from exceeding 4 tickets per event.
- Adjusted the view to pass the user and event to the form.

Note: Tests will be added in a follow-up PR.

Related issue: #3
