### PR TITLE
Feature/average_rating: Add average rating display for events

### DIFF
--- a/app/templates/app/event_detail.html
+++ b/app/templates/app/event_detail.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load rating_average %}
 
 {% block content %}
 <div class="container">
@@ -18,7 +19,23 @@
     </div>
     <div class="row">
         <div class="card mb-4">
-            <div class="card-body">
+            <div class="card-body position-relative">
+                {% if user_is_organizer %}
+                    {% average_rating event as avg_rating %}
+                    <div class="position-absolute top-0 end-0 m-3 text-end">
+                        <div class="bg-light border rounded p-3 shadow-sm">
+                            <h6 class="mb-1 text-muted">Promedio de Calificación</h6>
+                            {% if avg_rating %}
+                                <p class="mb-0">
+                                    <span class="fs-1 fw-bold text-primary">{{ avg_rating }}</span>
+                                    <span class="fs-5 text-primary">/ 5</span>
+                                </p>
+                            {% else %}
+                                <p class="mb-0 fst-italic text-muted">Este evento aún no ha sido calificado.</p>
+                            {% endif %}
+                        </div>
+                    </div>
+                {% endif %}
                 <h5 class="card-title">Detalles del Evento</h5>
                 <p class="card-text">{{ event.description }}</p>
                 <div class="mt-4">

--- a/app/templatetags/rating_average.py
+++ b/app/templatetags/rating_average.py
@@ -1,0 +1,10 @@
+from django import template
+from django.db.models import Avg
+from app.models import Rating
+
+register = template.Library()
+
+@register.simple_tag
+def average_rating(event):
+    avg = Rating.objects.filter(event=event).aggregate(avg=Avg('rating'))['avg']
+    return round(avg, 1) if avg is not None else None


### PR DESCRIPTION
This pull request adds a new feature that displays the average user rating for an event directly on the event detail page. The average rating is shown only to the event organizer and is formatted with one decimal place.

- Created a new template tag `rating_average` to calculate the average rating of an event.
- Updated `event_detail.html` to include the average rating display section.
- Restricted visibility of the average rating to the event organizer only.
- Styled the display with Bootstrap to highlight the score and maintain consistent UI.

Related Issue #15 