### PR TITLE
Feature/auto_event_change_notification : correctly create User_notification entries on event update

### DIFF
--- a/app/signals.py
+++ b/app/signals.py
@@ -1,7 +1,7 @@
 from django.db.models.signals import pre_save, post_save
 from django.dispatch import receiver
 from django.utils.timezone import localtime
-from .models import Event, Notification, Ticket
+from .models import Event, Notification, Ticket,User_Notification, User
 
 @receiver(pre_save, sender=Event)
 def detect_event_update(sender, instance, **kwargs):
@@ -67,3 +67,7 @@ def create_notification_on_event_update(sender, instance, created, **kwargs):
     user_ids = Ticket.objects.filter(event=instance).values_list("user_id", flat=True).distinct()
     notif.users.set(user_ids)
     notif.save()
+
+    users = User.objects.filter(id__in=user_ids)
+    for user in users:
+        User_Notification.objects.get_or_create(user=user, notification=notif)


### PR DESCRIPTION
Fixes a bug where User_Notification entries weren’t being created when an event was updated. Now, users with tickets get properly linked to the notification both via the users M2M and the User_Notification model.

Related Issue #1 