### PR TITLE
Add GitHub Actions CD pipeline for Docker build and deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,22 @@
-name: CD 
+name: CD
 
 on:
   release:
     types: [published]
   workflow_dispatch:
-  
+  push:
+    branches:
+      - main  # para deploy continuo al mergear PRs a main
+
 jobs:
   build-and-push:
     name: Build & Push Docker Image
     runs-on: ubuntu-latest
 
-    steps:
+    env:
+      IMAGE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || 'main-latest' }}
 
+    steps:
       - name: Clonar el código
         uses: actions/checkout@v3
 
@@ -24,12 +29,9 @@ jobs:
       - name: Construir imagen
         run: |
           docker build \
-            -t ${{ secrets.DOCKER_USERNAME }}/eventhub:${{ github.event.release.tag_name }} \
+            -t ${{ secrets.DOCKER_USERNAME }}/eventhub:${{ env.IMAGE_TAG }} \
             .
 
       - name: Subir imagen
         run: |
-          docker push ${{ secrets.DOCKER_USERNAME }}/eventhub:${{ github.event.release.tag_name }}
-  
-  #Se describen los pasos del deploy
-  #Tarea Asignada a Geronimo
+          docker push ${{ secrets.DOCKER_USERNAME }}/eventhub:${{ env.IMAGE_TAG }}


### PR DESCRIPTION
## Description

Set up the GitHub Actions workflow for Continuous Delivery:
- Builds and tags Docker image on push to `main` or release
- Pushes image to DockerHub

## How to Test

Push to `main` or create a release and verify DockerHub for the new image.

## Secrets Used

- `DOCKER_USERNAME`
- `DOCKER_PASSWORD`